### PR TITLE
Agregando imagen al pago y pequeño cambio en marcado de asistencia

### DIFF
--- a/android_app/app/src/main/java/com/longdrink/androidapp/fragments/MyAccountFragment.kt
+++ b/android_app/app/src/main/java/com/longdrink/androidapp/fragments/MyAccountFragment.kt
@@ -89,7 +89,7 @@ class MyAccountFragment : Fragment() {
         if (inscripcion != null){
             comprobarAsistencia(fechaActual, inscripcion!!.codInscripcion)
             if (!permitirAsistencia){
-                binding.myAccountAssistence.isEnabled = false
+                binding.myAccountAssistence.visibility = View.INVISIBLE
             }
             else{
                 binding.myAccountAssistence.setOnClickListener {

--- a/android_app/app/src/main/java/com/longdrink/androidapp/viewholders/PaymentsViewHolder.kt
+++ b/android_app/app/src/main/java/com/longdrink/androidapp/viewholders/PaymentsViewHolder.kt
@@ -8,11 +8,11 @@ import com.longdrink.androidapp.R
 import com.longdrink.androidapp.databinding.ListItemPaymentsBinding
 import com.longdrink.androidapp.model.Pago
 import com.longdrink.androidapp.utils.Utils
+import com.squareup.picasso.Picasso
 
 class PaymentsViewHolder(view : View) : RecyclerView.ViewHolder(view) {
 
     private val binding = ListItemPaymentsBinding.bind(view)
-    @SuppressLint("ResourceAsColor")
     fun bind(pago : Pago){
         binding.paymentDate.text = Utils.devolverFechaString(pago.fechaPago)
         binding.dueDate.text = " " + Utils.devolverFechaString(pago.fechaVencimiento)
@@ -23,20 +23,24 @@ class PaymentsViewHolder(view : View) : RecyclerView.ViewHolder(view) {
 
         if (fechaPago == "" && fechaHoy.after(fechaVencimiento)) {
             binding.state.text = "Vencido y Pendiente por pagar"
+            Picasso.get().load("https://cdn.icon-icons.com/icons2/1499/PNG/48/emblemimportant_103451.png").into(binding.paymentStateImage)
         }
         else if (fechaPago == "" && fechaHoy.before(fechaVencimiento)){
             binding.state.text = "Pendiente por pagar"
+            Picasso.get().load("https://cdn.icon-icons.com/icons2/1499/PNG/48/emblemimportant_103451.png").into(binding.paymentStateImage)
         }
         else if (fechaPago != ""){
             val fechaPagoDate = Utils.devolverFecha(pago.fechaPago)
             if(fechaPagoDate.after(fechaVencimiento)){
                 binding.state.text = "Vencido y Pagado"
+                Picasso.get().load("https://cdn.icon-icons.com/icons2/317/PNG/48/sign-check-icon_34365.png").into(binding.paymentStateImage)
+
             }
             else{
                 binding.state.text = "Pagado"
+                Picasso.get().load("https://cdn.icon-icons.com/icons2/317/PNG/48/sign-check-icon_34365.png").into(binding.paymentStateImage)
             }
         }
 
-        /*TODO: FALTA AGREGAR LA IMAGEN*/
     }
 }


### PR DESCRIPTION
Se agregaron las imágenes al listado de pagos de pendiendo si ya se ha pagado o no. Además de dejar invisible el botón de marcado de asistencia en el caso de que ese día no toque asistir a clases